### PR TITLE
Aktualizacja wersji bibliotek Github Actions

### DIFF
--- a/.github/workflows/oob_pipeline.yml
+++ b/.github/workflows/oob_pipeline.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Archive Test Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: testing-outputs
           path: |


### PR DESCRIPTION
Zmiana z `actions/checkout@v4` na `actions/checkout@v5`.
Zmiana z `actions/setup-python@v4` na `actions/setup-python@v6`.
Zmiana z `actions/upload-artifact@v4` na `actions/upload-artifact@v6`.

*Zmiany zostały wymuszone przez zmianę wspieranej wersji Node.js przez Github z Node 20 na Node 24*