### PR TITLE
Poprawki generatora raportów

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 Pillow
 pytest
 pytest-cov
+tzdata

--- a/scripts/report_generator.py
+++ b/scripts/report_generator.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timezone, timedelta
-from zoneinfo import ZoneInfo
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from importlib.metadata import version
 import xml.etree.ElementTree as ET
 import os, sys, platform, socket, configparser
@@ -51,8 +51,12 @@ def get_coverage_data(cov_file):
     }
 
 def get_report_timestamp():
-    warsaw_time = datetime.now(ZoneInfo("Europe/Warsaw"))
-    return warsaw_time.strftime("%Y-%m-%d %H:%M %Z")
+    try:
+        report_time = datetime.now(ZoneInfo("Europe/Warsaw"))
+    except ZoneInfoNotFoundError:
+        report_time = datetime.now().astimezone()
+
+    return report_time.strftime("%Y-%m-%d %H:%M %Z")
 
 def get_hostname():
     return os.getenv("RUNNER_NAME") or socket.gethostname()
@@ -121,15 +125,31 @@ def create_test_summary(output_file, test_results):
         f.write("---\n\n")
 
 def create_enviroment_details(output_file):
-    with open(output_file, 'a') as f:
+    dependencies = get_dependencies()
+    pytest_config = get_pytest_config()
+
+    with open(output_file, 'a', encoding="utf-8") as f:
         f.write("## Test Environment Details\n\n")
         f.write(f"**Timestamp:** `{get_report_timestamp()}`\n")
         f.write(f"**Environment:** `Python {sys.version.split()[0]} | {platform.system()} {platform.release()}`\n\n")
         f.write(f"* **Host:** `{get_hostname()}`\n" + 
                 f"* **Interpreter:** `CPython {sys.version.split()[0]}`\n" +
-                f"* **Dependencies:**\n" + 
-                f"  * `pytest`: `{version('pytest')}`\n")
-        f.write(f"* **Plugin Config:** `pytest-cov`\n")
+                f"* **Dependencies:**\n")
+        for dependency in dependencies:
+            f.write(f"  * `{dependency}`\n")
+        f.write(f"* **Pytest Config:**\n")
+        if "error" in pytest_config:
+            f.write(f"  * `{pytest_config['error']}`\n")
+        else:
+            if pytest_config["testpaths"]:
+                f.write(f"  * `testpaths`: `{pytest_config['testpaths']}`\n")
+
+            if pytest_config["addopts"]:
+                f.write("  * `addopts`:\n")
+                for option in pytest_config["addopts"].splitlines():
+                    option = option.strip()
+                    if option:
+                        f.write(f"    * `{option}`\n")
         f.write("\n\n---\n\n")
 
 def create_failure_report(output_file, test_results):

--- a/scripts/report_generator.py
+++ b/scripts/report_generator.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from datetime import datetime, timezone, timedelta
+from zoneinfo import ZoneInfo
 from importlib.metadata import version
 import xml.etree.ElementTree as ET
-import os, sys, platform
+import os, sys, platform, socket, configparser
 
 
 def get_test_results(xml_file):
@@ -50,6 +50,44 @@ def get_coverage_data(cov_file):
         "percentage": percentage
     }
 
+def get_report_timestamp():
+    warsaw_time = datetime.now(ZoneInfo("Europe/Warsaw"))
+    return warsaw_time.strftime("%Y-%m-%d %H:%M %Z")
+
+def get_hostname():
+    return os.getenv("RUNNER_NAME") or socket.gethostname()
+
+def get_dependencies(requirements_file="requirements.txt"):
+    if not os.path.exists(requirements_file):
+        return [f"requirements file not found: {requirements_file}"]
+
+    dependencies = []
+
+    with open(requirements_file, encoding="utf-8") as file:
+        for line in file:
+            dependency = line.strip()
+
+            if dependency and not dependency.startswith("#"):
+                dependencies.append(dependency)
+
+    return dependencies
+
+def get_pytest_config(pytest_ini_file="pytest.ini"):
+    if not os.path.exists(pytest_ini_file):
+        return {"error": f"pytest config not found: {pytest_ini_file}"}
+
+    parser = configparser.ConfigParser()
+    parser.read(pytest_ini_file, encoding="utf-8")
+
+    if "pytest" not in parser:
+        return {"error": "missing [pytest] section"}
+
+    return {
+        "testpaths": parser["pytest"].get("testpaths", "").strip(),
+        "addopts": parser["pytest"].get("addopts", "").strip(),
+    }
+
+
 def create_header(output_file, test_results, coverage_data):
     if test_results["failures"] + test_results["errors"] == 0:
         pass_badge = ['Passed', 'success']
@@ -85,11 +123,9 @@ def create_test_summary(output_file, test_results):
 def create_enviroment_details(output_file):
     with open(output_file, 'a') as f:
         f.write("## Test Environment Details\n\n")
-        now = datetime.now()
-        pl_time = now.astimezone(timezone(timedelta(hours=1))) if now.astimezone().tzname() != 'CET' else now
-        f.write(f"**Timestamp:** `{pl_time.strftime('%Y-%m-%d %H:%M')}`\n")
+        f.write(f"**Timestamp:** `{get_report_timestamp()}`\n")
         f.write(f"**Environment:** `Python {sys.version.split()[0]} | {platform.system()} {platform.release()}`\n\n")
-        f.write(f"* **Host:** `{os.getenv('RUNNER_NAME', 'GitHub-Runner')}`\n" + 
+        f.write(f"* **Host:** `{get_hostname()}`\n" + 
                 f"* **Interpreter:** `CPython {sys.version.split()[0]}`\n" +
                 f"* **Dependencies:**\n" + 
                 f"  * `pytest`: `{version('pytest')}`\n")


### PR DESCRIPTION
* Raport poprawnie wymienia `dependencies` projektu
* Raport poprawnie podaje godzinę wykonania testu w strefie `Europe/Warsaw`
* Raport podaje dane konfiguracyjne środowiska testowego na bazie `pytest.ini`